### PR TITLE
use v2 tags consistently

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -13,15 +13,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.1.2'
-      - uses: r-lib/actions/setup-pandoc@v1
+          r-version: '4.2.0'
+      - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 2
 
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: _book
           path: _book/

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.1.2'
-      - uses: r-lib/actions/setup-pandoc@v1
+          r-version: '4.2.0'
+      - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 2


### PR DESCRIPTION
also switch to R4.2.0 as the base R version in case someone starts using the new `_` placeholder