### PR TITLE
Ignore build files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@
 _book
 _bookdown_files
 bookclub-BOOKABBR.Rmd
+bookclub-BOOKABBR.html
+bookclub-BOOKABBR.knit.md
 bookclub-BOOKABBR_files
+libs


### PR DESCRIPTION
Sometimes these get left behind if something fails, and that can pollute PRs.